### PR TITLE
Add missing @compat fieldnames

### DIFF
--- a/src/timbertruck.jl
+++ b/src/timbertruck.jl
@@ -4,7 +4,7 @@ log(t::TimberTruck, a::Dict) = error("please implement `log(truck::$(typeof(t)),
 
 
 function configure(t::TimberTruck; mode = nothing)
-    !in(:_mode, names(t)) && return
+    !in(:_mode, @compat fieldnames(t)) && return
     t._mode = mode
 end
 


### PR DESCRIPTION
Fixes the following error:
```julia
               _
   _       _ _(_)_     |  A fresh approach to technical computing
  (_)     | (_) (_)    |  Documentation: http://docs.julialang.org
   _ _   _| |_  __ _   |  Type "?help" for help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 0.4.0-dev+6858 (2015-08-20 16:45 UTC)
 _/ |\__'_|_|_|\__'_|  |  Commit dc2be6f (0 days old master)
|__/                   |  x86_64-apple-darwin14.4.0

julia> using Lumberjack

julia> Lumberjack.configure(Lumberjack._lumber_mill.timber_trucks["console"]; mode = "warn")
WARNING: names(v) is deprecated, use fieldnames(v) instead.
 in depwarn at ./deprecated.jl:63
 in names at deprecated.jl:49
 in configure at /Users/rasmus/.julia/v0.4/Lumberjack/src/timbertruck.jl:7
while loading no file, in expression starting on line 0
"warn"
```

Tests pass on 0.3 for me locally. Tests don't pass on 0.4, but that seems to be irrespective of this change.