### PR TITLE
Modified file roller to track number of bytes written

### DIFF
--- a/src/FileRoller.jl
+++ b/src/FileRoller.jl
@@ -1,12 +1,13 @@
 import Base.println, Base.flush
 
-FILE_SIZE = 5000 * 1028 
+FILE_SIZE = 5000 * 1028
 
 type FileRoller <: IO
     prefix::String
     folder::String
     filepath::String
     file::IO
+    byteswritten::Int64
 end
 
 function getsuffix(n::Integer)
@@ -28,17 +29,18 @@ function getfile(folder::String, prefix::String)
     p, open(p, "a")
 end
 
-FileRoller(prefix) = FileRoller(prefix, pwd(), (getfile(pwd(), prefix))...)
+FileRoller(prefix) = FileRoller(prefix, pwd(), (getfile(pwd(), prefix))..., 0)
 
-FileRoller(prefix, dir) = FileRoller((getfile(pwd(), prefix))...)
+FileRoller(prefix, dir) = FileRoller((getfile(dir, prefix))...)
 
 function println(f::FileRoller, s::String)
-    if filesize(f.filepath) > FILE_SIZE
+    if f.byteswritten > FILE_SIZE
         gf = getfile(f.folder, f.prefix)
         f.filepath = gf[1]
         f.file = gf[2]
+        f.byteswritten = 0
     end
-    println(f.file, s)
+    f.byteswritten += write(f.file, "$s\n")
 end
 
 flush(f::FileRoller) = flush(f.file)


### PR DESCRIPTION
Rather than calling `filesize` every time a log line is written.

The performance benefit is lower than I expected (about 10%) but I think it's a cleaner implementation. Also, this fixes a typo with the second constructor of `FileRoller`, allowing the user to specify the base directory.