### PR TITLE
Avoid storing reference to STDOUT during compile time

### DIFF
--- a/src/Lumberjack.jl
+++ b/src/Lumberjack.jl
@@ -34,4 +34,10 @@ include("FileRoller.jl")
 
 # -------
 
+function __init__()
+    global const _lumber_mill = LumberMill()
+end
+
+# -------
+
 end

--- a/src/lumbermill.jl
+++ b/src/lumbermill.jl
@@ -1,4 +1,3 @@
-
 type LumberMill
     timber_trucks::Dict{Any, TimberTruck}
     saws::Array
@@ -152,9 +151,3 @@ function get_mode_index(lm::LumberMill, mode)
     index = findfirst(lm.modes, mode)
     index > 0 ? index : length(lm.modes) + 1
 end
-
-# -------
-
-_lumber_mill = LumberMill()
-
-# -------


### PR DESCRIPTION
This PR introduces an `__init__` function which creates the standard lumber mill during run time, thus avoiding storing a reference to an invalid `STDOUT` from compile time, as discussed in JuliaLang/julia#13136.

Although I can't find anything in the Julia docs about it, it seems that the `__init__` function is called by julia 0.3 as well.

Before
```julia
julia> using Lumberjack
INFO: Precompiling module Lumberjack...

julia> Lumberjack.warn("Hello")

signal (11): Segmentation fault: 11
uv_write2 at /Users/rasmus/dev/src/julia/deps/libuv/src/unix/stream.c:1282
jl_uv_write at /Users/rasmus/dev/src/julia/src/jl_uv.c:358
uv_write at ./stream.jl:941
buffer_or_write at ./stream.jl:981
write at ./stream.jl:1005
print at ./strings/io.jl:29
jlcall_print_19162 at /Users/rasmus/dev/src/julia/usr/lib/julia/sys.dylib (unknown line)
with_output_color at util.jl:316
jl_apply at /Users/rasmus/dev/src/julia/src/./julia.h:1269
print_with_color at util.jl:320
jl_apply at /Users/rasmus/dev/src/julia/src/gf.c:1691
log at /Users/rasmus/.julia/v0.4/Lumberjack/src/timbertruck.jl:113
jl_apply at /Users/rasmus/dev/src/julia/src/gf.c:1691
log at /Users/rasmus/.julia/v0.4/Lumberjack/src/lumbermill.jl:52
warn at /Users/rasmus/.julia/v0.4/Lumberjack/src/lumbermill.jl:75
jlcall_warn_21457 at  (unknown line)
jl_apply at /Users/rasmus/dev/src/julia/src/gf.c:1691
warn at /Users/rasmus/.julia/v0.4/Lumberjack/src/lumbermill.jl:91
julia_warn_21455 at  (unknown line)
jl_apply at /Users/rasmus/dev/src/julia/src/gf.c:1691
jl_apply at /Users/rasmus/dev/src/julia/src/interpreter.c:55
eval at /Users/rasmus/dev/src/julia/src/interpreter.c:213
jl_toplevel_eval_flex at /Users/rasmus/dev/src/julia/src/toplevel.c:527
jl_toplevel_eval_in at /Users/rasmus/dev/src/julia/src/builtins.c:569
eval_user_input at REPL.jl:64
jlcall_eval_user_input_21261 at  (unknown line)
anonymous at REPL.jl:93
jl_apply at /Users/rasmus/dev/src/julia/src/task.c:241
[1]    25656 segmentation fault  julia-dev
```

After
```julia
julia> using Lumberjack
INFO: Recompiling stale cache file /Users/rasmus/.julia/lib/v0.4/Lumberjack.ji for module Lumberjack.

julia> Lumberjack.warn("Hello")
2015-09-15T10:30:07 - warn: Hello
```

```julia
julia> versioninfo()
Julia Version 0.4.0-rc1+33
Commit a0fa6af (2015-09-13 16:27 UTC)
Platform Info:
  System: Darwin (x86_64-apple-darwin14.4.0)
  CPU: Intel(R) Core(TM) i7-2635QM CPU @ 2.00GHz
  WORD_SIZE: 64
  BLAS: libopenblas (USE64BITINT DYNAMIC_ARCH NO_AFFINITY Sandybridge)
  LAPACK: libopenblas
  LIBM: libopenlibm
  LLVM: libLLVM-3.3
```