### PR TITLE
Julia 0.4 compatability fixes.

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,6 +1,6 @@
 julia 0.3
 
 Compat
-UUID
+UUID # required for Julia 0.3, not used if running with Julia 0.4
 JSON
 Dates

--- a/src/FileRoller.jl
+++ b/src/FileRoller.jl
@@ -3,9 +3,9 @@ import Base.println, Base.flush
 FILE_SIZE = 5000 * 1028
 
 type FileRoller <: IO
-    prefix::String
-    folder::String
-    filepath::String
+    prefix::@compat AbstractString
+    folder::@compat AbstractString
+    filepath::@compat AbstractString
     file::IO
     byteswritten::Int64
 end
@@ -18,7 +18,7 @@ function getsuffix(n::Integer)
     str
 end
 
-function getfile(folder::String, prefix::String)
+function getfile(folder::@compat(AbstractString), prefix::@compat(AbstractString))
     i = 1
     getpath(i) = joinpath(folder, "$(prefix).$(getsuffix(i))")
     p = getpath(i)
@@ -33,7 +33,7 @@ FileRoller(prefix) = FileRoller(prefix, pwd(), (getfile(pwd(), prefix))..., 0)
 
 FileRoller(prefix, dir) = FileRoller((getfile(dir, prefix))...)
 
-function println(f::FileRoller, s::String)
+function println(f::FileRoller, s::@compat AbstractString)
     if f.byteswritten > FILE_SIZE
         gf = getfile(f.folder, f.prefix)
         f.filepath = gf[1]

--- a/src/Lumberjack.jl
+++ b/src/Lumberjack.jl
@@ -6,11 +6,11 @@ import Base.show, Base.log
 
 # To avoid warnings, intentionally do not import:
 # Base.error, Base.warn, Base.info
-using UUID, Compat
+using Compat
 
 # for backwards compatibility with 0.3:
 if VERSION < v"0.4.0-"
-    using Dates
+    using Dates, UUID
 end
 
 export log,

--- a/src/lumbermill.jl
+++ b/src/lumbermill.jl
@@ -32,7 +32,7 @@ end
 configure(; args...) = configure(_lumber_mill; args...)
 
 
-function log(lm::LumberMill, mode::String, msg::String, args::Dict = Dict())
+function log(lm::LumberMill, mode::@compat(AbstractString), msg::@compat(AbstractString), args::Dict = Dict())
     args[:mode] = mode
     args[:msg] = msg
 
@@ -52,30 +52,30 @@ function log(lm::LumberMill, mode::String, msg::String, args::Dict = Dict())
     end
 end
 
-log(mode::String, msg::String, args::Dict = Dict()) = log(_lumber_mill, mode, msg, args)
+log(mode::@compat(AbstractString), msg::@compat(AbstractString), args::Dict = Dict()) = log(_lumber_mill, mode, msg, args)
 
-log(mode::String, args::Dict = Dict()) = log(_lumber_mill, mode, "", args)
-
-
-debug(lm::LumberMill, msg::String, args::Dict = Dict()) = log(lm, "debug", msg, args)
-
-debug(msg::String, args::Dict) = debug(_lumber_mill, msg, args)
-
-debug(msg::String...) = debug(_lumber_mill, string(msg...))
+log(mode::@compat(AbstractString), args::Dict = Dict()) = log(_lumber_mill, mode, "", args)
 
 
-info(lm::LumberMill, msg::String, args::Dict = Dict()) = log(lm, "info", msg, args)
+debug(lm::LumberMill, msg::@compat(AbstractString), args::Dict = Dict()) = log(lm, "debug", msg, args)
 
-info(msg::String, args::Dict) = info(_lumber_mill, msg, args)
+debug(msg::@compat(AbstractString), args::Dict) = debug(_lumber_mill, msg, args)
 
-info(msg::String...; prefix = "info: ") = info(_lumber_mill, string(msg...))
+debug(msg::@compat(AbstractString)...) = debug(_lumber_mill, string(msg...))
 
 
-warn(lm::LumberMill, msg::String, args::Dict = Dict()) = log(lm, "warn", msg, args)
+info(lm::LumberMill, msg::@compat(AbstractString), args::Dict = Dict()) = log(lm, "info", msg, args)
 
-warn(msg::String, args::Dict) = warn(_lumber_mill, msg, args)
+info(msg::@compat(AbstractString), args::Dict) = info(_lumber_mill, msg, args)
 
-function warn(msg::String...; prefix="warning: ", once = false, key = nothing, bt = nothing)
+info(msg::@compat(AbstractString)...; prefix = "info: ") = info(_lumber_mill, string(msg...))
+
+
+warn(lm::LumberMill, msg::@compat(AbstractString), args::Dict = Dict()) = log(lm, "warn", msg, args)
+
+warn(msg::@compat(AbstractString), args::Dict) = warn(_lumber_mill, msg, args)
+
+function warn(msg::@compat(AbstractString)...; prefix="warning: ", once = false, key = nothing, bt = nothing)
     str = chomp(bytestring(msg...))
 
     if once
@@ -94,7 +94,7 @@ warn(err::Exception; prefix = "error: ", kw...) =
     warn(sprint(io->showerror(io,err)), prefix = prefix; kw...)
 
 
-function error(lm::LumberMill, msg::String, args::Dict = Dict())
+function error(lm::LumberMill, msg::@compat(AbstractString), args::Dict = Dict())
     exception_msg = copy(msg)
     length(args) > 0 && (exception_msg *= " $args")
 
@@ -103,7 +103,7 @@ function error(lm::LumberMill, msg::String, args::Dict = Dict())
     throw(ErrorException(exception_msg))
 end
 
-error(msg::String, args::Dict) = error(_lumber_mill, msg, args)
+error(msg::@compat(AbstractString), args::Dict) = error(_lumber_mill, msg, args)
 
 error(msg...) = error(_lumber_mill, string(msg...))
 

--- a/src/lumbermill.jl
+++ b/src/lumbermill.jl
@@ -127,11 +127,19 @@ function remove_saws(lm::LumberMill = _lumber_mill)
 end
 
 
-function add_truck(lm::LumberMill, truck::TimberTruck, name = string(UUID.v4()))
-    lm.timber_trucks[name] = truck
-end
+if VERSION < v"0.4.0-"
+    function add_truck(lm::LumberMill, truck::TimberTruck, name = string(UUID.v4()))
+        lm.timber_trucks[name] = truck
+    end
 
-add_truck(truck::TimberTruck, name = string(UUID.v4())) = add_truck(_lumber_mill, truck, name)
+    add_truck(truck::TimberTruck, name = string(UUID.v4())) = add_truck(_lumber_mill, truck, name)
+else
+    function add_truck(lm::LumberMill, truck::TimberTruck, name = string(Base.Random.uuid4()))
+        lm.timber_trucks[name] = truck
+    end
+
+    add_truck(truck::TimberTruck, name = string(Base.Random.uuid4())) = add_truck(_lumber_mill, truck, name)
+end
 
 
 function remove_truck(lm::LumberMill, name)

--- a/src/timbertruck.jl
+++ b/src/timbertruck.jl
@@ -22,7 +22,7 @@ type CommonLogTruck <: TimberTruck
 
     CommonLogTruck(out::IO, mode = nothing) = new(out, mode)
 
-    function CommonLogTruck(filename::String, mode = nothing)
+    function CommonLogTruck(filename::@compat(AbstractString), mode = nothing)
         file = open(filename, "a")
         truck = new(file, mode)
         finalizer(truck, (t)->close(t.out))
@@ -49,7 +49,7 @@ type LumberjackTruck <: TimberTruck
 
     LumberjackTruck(out::IO, mode = nothing) = new(out, mode)
 
-    function LumberjackTruck(filename::String, mode = nothing, opts = Dict())
+    function LumberjackTruck(filename::@compat(AbstractString), mode = nothing, opts = Dict())
         file = open(filename, "a")
         setup_opts(opts)
         truck = new(file, mode, opts)


### PR DESCRIPTION
Hello,

This fixes two issues to make Lumberjack more compatible with Julia 0.4:

* Use `Base.Random.uuid4()` instead of `UUID.v4()`
* Replace `String` with `AbstractString`

In both cases, I have attempted to make the changes backward compatible with Julia 0.3.

Thanks for your time and your excellent package.

Sam